### PR TITLE
don't error if PR already exists

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -98,6 +99,9 @@ var planCmd = &cobra.Command{
 				if err != nil {
 					eg.Error(err)
 					return
+				}
+				if singleRepo != "" {
+					fmt.Println(output.GitDiff)
 				}
 			}(plan.Input{
 				RepoName:      r.Name,

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -85,6 +85,7 @@ var pushCmd = &cobra.Command{
 					return
 				}
 			}(push.Input{
+				RepoName:   r.Name,
 				PlanDir:    planOutput.PlanDir,
 				WorkDir:    pushWorkDir,
 				PRMessage:  planOutput.CommitMessage,


### PR DESCRIPTION
Ran into this when pushing out node 8 PRs.

This enables a `plan` + `push` iteration cycle where you iterate on
`plan`, `push` the result, and either create a new PR or
update an existing PR.

Also tweaked `plan` to output the git diff if you give it a single
repo, which enables small-scale iteration on `plan` before you `push`.