### PR TITLE
Adds UX improvements around push and merge

### DIFF
--- a/merge/merge.go
+++ b/merge/merge.go
@@ -84,5 +84,11 @@ func Merge(ctx context.Context, input Input) (Output, error) {
 		return Output{Success: false}, fmt.Errorf("failed to merge: %s", result.GetMessage())
 	}
 
+	// Delete the branch
+	_, err = client.Git.DeleteRef(ctx, input.Org, input.Repo, "heads/"+*pr.Head.Ref)
+	if err != nil {
+		return Output{Success: false}, err
+	}
+
 	return Output{Success: true, MergeCommitSHA: result.GetSHA()}, nil
 }


### PR DESCRIPTION
This adds two changes from https://clever.atlassian.net/browse/INFRA-2617

1) After merging, we will delete the branch associated with the PR using the [delete-a-reference](https://developer.github.com/v3/git/refs/#delete-a-reference) API.

2) After pushing, we display the opened issues using the commit message as the query.