### PR TITLE
Refactor to include errors in JSON from commands

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -74,12 +74,16 @@ var cloneCmd = &cobra.Command{
 				defer eg.Done()
 				log.Printf("cloning: %s", cloneInput.GitURL)
 				output, err := clone.Clone(ctx, cloneInput)
-				// TODO: should we also write the error? only saving output means "status" command only has Success: true/false to work with
-				writeJSON(output, cloneOutputPath)
 				if err != nil {
+					o := struct {
+						clone.Output
+						Error string
+					}{output, err.Error()}
+					writeJSON(o, cloneOutputPath)
 					eg.Error(err)
 					return
 				}
+				writeJSON(output, cloneOutputPath)
 			}(clone.Input{
 				WorkDir: cloneWorkDir,
 				GitURL:  r.CloneURL,

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -70,12 +70,16 @@ var mergeCmd = &cobra.Command{
 				defer eg.Done()
 				log.Printf("merging: %v", input)
 				output, err := merge.Merge(ctx, input)
-				// TODO: should we also write the error? only saving output means "status" command only has Success: true/false to work with
-				writeJSON(output, mergeOutputPath)
 				if err != nil {
+					o := struct {
+						merge.Output
+						Error string
+					}{output, err.Error()}
+					writeJSON(o, mergeOutputPath)
 					eg.Error(err)
 					return
 				}
+				writeJSON(output, mergeOutputPath)
 			}(merge.Input{
 				Org:       "Clever", // TODO
 				Repo:      r.Name,

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -89,12 +89,16 @@ var planCmd = &cobra.Command{
 				defer eg.Done()
 				log.Printf("planning: %s", input)
 				output, err := plan.Plan(ctx, input)
-				// TODO: should we also write the error? only saving output means "status" command only has Success: true/false to work with
-				writeJSON(output, planOutputPath)
 				if err != nil {
+					o := struct {
+						plan.Output
+						Error string
+					}{output, err.Error()}
+					writeJSON(o, planOutputPath)
 					eg.Error(err)
 					return
 				}
+				writeJSON(output, planOutputPath)
 				if singleRepo != "" {
 					fmt.Println(output.GitDiff)
 				}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -79,12 +79,16 @@ var pushCmd = &cobra.Command{
 				defer eg.Done()
 				log.Printf("pushing: %s", input)
 				output, err := push.Push(ctx, input)
-				// TODO: should we also write the error? only saving output means "status" command only has Success: true/false to work with
-				writeJSON(output, pushOutputPath)
 				if err != nil {
+					o := struct {
+						push.Output
+						Error string
+					}{output, err.Error()}
+					writeJSON(o, pushOutputPath)
 					eg.Error(err)
 					return
 				}
+				writeJSON(output, pushOutputPath)
 			}(push.Input{
 				RepoName:   r.Name,
 				PlanDir:    planOutput.PlanDir,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -91,30 +91,51 @@ func printStatus(repos []string) {
 func getRepoStatus(repo string) (status, details string) {
 	status = "initialized"
 	details = ""
-	var cloneOutput clone.Output
+	var cloneOutput struct {
+		clone.Output
+		Error string
+	}
 	if !(loadJSON(outputPath(repo, "clone"), &cloneOutput) == nil && cloneOutput.Success) {
+		if cloneOutput.Error != "" {
+			details = "(clone error) " + cloneOutput.Error
+		}
 		return
 	}
 	status = "cloned"
 
-	var planOutput plan.Output
+	var planOutput struct {
+		plan.Output
+		Error string
+	}
 	if !(loadJSON(outputPath(repo, "plan"), &planOutput) == nil && planOutput.Success) {
-		if planOutput.Details != "" {
-			details = "(plan error) " + planOutput.Details
+		if planOutput.Error != "" {
+			details = "(plan error) " + planOutput.Error
 		}
 		return
 	}
 	status = "planned"
 
-	var pushOutput push.Output
+	var pushOutput struct {
+		push.Output
+		Error string
+	}
 	if !(loadJSON(outputPath(repo, "push"), &pushOutput) == nil && pushOutput.Success) {
+		if pushOutput.Error != "" {
+			details = "(push error) " + pushOutput.Error
+		}
 		return
 	}
 	status = "pushed"
 	details = pushOutput.String()
 
-	var mergeOutput merge.Output
+	var mergeOutput struct {
+		merge.Output
+		Error string
+	}
 	if !(loadJSON(outputPath(repo, "merge"), &mergeOutput) == nil && mergeOutput.Success) {
+		if mergeOutput.Error != "" {
+			details = "(merge error) " + mergeOutput.Error
+		}
 		return
 	}
 	status = "merged"

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -35,7 +35,6 @@ type Input struct {
 // Output for Plan
 type Output struct {
 	Success bool
-	Details string
 
 	PlanDir       string
 	GitDiff       string
@@ -54,8 +53,7 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 	cmd := exec.CommandContext(ctx, "cp", "-r", "./.", planDir) // "./." copies all the contents of the current directory into the target directory
 	cmd.Dir = input.RepoDir
 	if output, err := cmd.CombinedOutput(); err != nil {
-		details := string(output)
-		return Output{Success: false, Details: details}, errors.New(details)
+		return Output{Success: false}, errors.New(string(output))
 	}
 
 	// run the change command, git add, and git commit
@@ -70,8 +68,7 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 		// Set MICROPLANE_<X> convenience env vars, for use in user's script
 		execCmd.Env = append(os.Environ(), fmt.Sprintf("MICROPLANE_REPO=%s", input.RepoName))
 		if output, err := execCmd.CombinedOutput(); err != nil {
-			details := string(output)
-			return Output{Success: false, Details: details}, errors.New(details)
+			return Output{Success: false}, errors.New(string(output))
 		}
 	}
 
@@ -81,8 +78,7 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 	gitDiffCmd.Dir = planDir
 	output, err := gitDiffCmd.CombinedOutput()
 	if err != nil {
-		details := string(output)
-		return Output{Success: false, Details: details}, errors.New(details)
+		return Output{Success: false}, errors.New(string(output))
 	}
 	gitDiff = string(output)
 


### PR DESCRIPTION
[INFRA-2649](https://clever.atlassian.net/browse/INFRA-2649)

I took a crack at refactoring our error handling here so that we can surface the errors in `mp status`.

In general, I wanted to preserve the Go-style error handling (e.g. returning `Output, error` from functions) while not modifying the JSON structure too much. I used anonymous `structs`, but as a Go neophyte, I'm not confident this is a good approach.

Happy to hear any feedback!