### PR TITLE
Explicitly meter calls to Github API. Remove retrier.

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -60,7 +60,7 @@ func mergeOneRepo(r initialize.Repo, ctx context.Context) error {
 		PRNumber:  prNumber,
 		CommitSHA: pushOutput.CommitSHA,
 	}
-	output, err := merge.Merge(ctx, input)
+	output, err := merge.Merge(ctx, input, githubLimiter)
 	if err != nil {
 		o := struct {
 			merge.Output

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -75,7 +75,7 @@ func pushOneRepo(r initialize.Repo, ctx context.Context) error {
 		BranchName: planOutput.BranchName,
 		RepoOwner:  r.Owner,
 	}
-	output, err := push.Push(ctx, input)
+	output, err := push.Push(ctx, input, githubLimiter)
 	if err != nil {
 		o := struct {
 			push.Output

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/Clever/microplane/initialize"
 	"github.com/spf13/cobra"
@@ -13,6 +14,10 @@ import (
 
 var workDir string
 var cliVersion string
+
+// Github's rate limit for authenticated requests is 5000 QPH = 83.3 QPM = 1.38 QPS = 720ms/query
+// We also use a global limiter to prevent concurrent requests, which trigger Github's abuse detection
+var githubLimiter = time.NewTicker(720 * time.Millisecond)
 
 var rootCmd = &cobra.Command{
 	Use:   "mp",


### PR DESCRIPTION
We do this because the Github API triggers abuse warnings if a single
user makes lots of concurrent requests. By having a shared ticker, we
ensure that Github API requests don't happen in parallel.

Moreover, we also ensure that there's a global rate limit of 1 request
to the GithubAPI per 720 milliseconds. We're following the approach
shown here: https://github.com/google/go-github/issues/431

This means that we'll stay within the rate limit requirement
of 5000 requests-per-hour for authenticated users.

```
5000 QPH = 83.3 QPM = 1.38 QPS = 720ms/query
```