### PR TITLE
Split multiline commit message into PR title and body

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -101,8 +101,15 @@ func Push(ctx context.Context, input Input, githubLimiter *time.Ticker) (Output,
 	head := fmt.Sprintf("%s:%s", input.RepoOwner, input.BranchName)
 	base := "master"
 
+	splitMsg := strings.SplitN(input.PRMessage, "\n", 2)
+	title := splitMsg[0]
+	body := ""
+	if len(splitMsg) == 2 {
+		body = splitMsg[1]
+	}
 	pr, err := findOrCreatePR(ctx, client, input.RepoOwner, input.RepoName, &github.NewPullRequest{
-		Title: &input.PRMessage,
+		Title: &title,
+		Body:  &body,
 		Head:  &head,
 		Base:  &base,
 	}, githubLimiter)


### PR DESCRIPTION
If you do `mp plan -m "title\nbody"`, this now results in a PR title of `title` and a PR body of `body`. Previously, it would join the multi-line string into a giant single line PR title. Not good.