### PR TITLE
Improve mp status output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,16 +14,16 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/eapache/go-resiliency"
-  packages = ["retrier"]
-  revision = "6800482f2c813e689c88b7ed3282262385011890"
-  version = "v1.0.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/facebookgo/errgroup"
   packages = ["."]
   revision = "779c8d7ef069c522bc72ee5f31a98d89a37f3fb6"
+
+[[projects]]
+  name = "github.com/fatih/color"
+  packages = ["."]
+  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
@@ -48,6 +48,24 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/juju/errors"
+  packages = ["."]
+  revision = "c7d06af17c68cd34c835053720b21f6549d9b0ee"
+
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -81,6 +99,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/waigani/diffparser"
+  packages = ["."]
+  revision = "6198bead10008c43fcba66f16addbf23d6301ce9"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp"]
   revision = "aabf50738bcdd9b207582cbe796b59ed65d56680"
@@ -98,6 +122,12 @@
   revision = "8e0aa688b654ef28caa72506fa5ec8dba9fc7690"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "28a7276518d399b9634904daad79e18b44d481bc"
+
+[[projects]]
   name = "google.golang.org/appengine"
   packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
@@ -112,6 +142,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6153c9bbd44bfc724d11a947b61e1b6d8d61bdae1a8e5ce6e8cb4f7827ba6bee"
+  inputs-digest = "5286b26c9e73af39b33bb5ee44de35f60e82b7704bc6f4273239c624779dc1ba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,6 +68,12 @@
   version = "v0.0.3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/nathanleiby/diffparser"
+  packages = ["."]
+  revision = "936553ce5db1b73e63cbcd7546416d13538e8d85"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -96,12 +102,6 @@
   packages = ["assert"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/waigani/diffparser"
-  packages = ["."]
-  revision = "6198bead10008c43fcba66f16addbf23d6301ce9"
 
 [[projects]]
   branch = "master"
@@ -142,6 +142,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5286b26c9e73af39b33bb5ee44de35f60e82b7704bc6f4273239c624779dc1ba"
+  inputs-digest = "4794c55e2cf557ed5f3cade9ed34703693efa60880ecf8b444717d641fc0e8dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,11 @@
   branch = "master"
   name = "github.com/facebookgo/errgroup"
 
+# Using a fork, awaiting PR: https://github.com/waigani/diffparser/pull/9
+[[constraint]]
+  name = "github.com/nathanleiby/diffparser"
+  branch = "master"
+
 [[constraint]]
   branch = "master"
   name = "golang.org/x/sync"

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -13,8 +13,8 @@ import (
 	"github.com/Clever/microplane/plan"
 	"github.com/Clever/microplane/push"
 	"github.com/fatih/color"
+	"github.com/nathanleiby/diffparser"
 	"github.com/spf13/cobra"
-	"github.com/waigani/diffparser"
 )
 
 var statusCmd = &cobra.Command{

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Clever/microplane/push"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/waigani/diffparser"
 )
 
 var statusCmd = &cobra.Command{
@@ -115,6 +116,10 @@ func getRepoStatus(repo string) (status, details string) {
 		return
 	}
 	status = "planned"
+	diff, err := diffparser.Parse(planOutput.GitDiff)
+	if err == nil {
+		details = fmt.Sprintf("%d file(s) modified", len(diff.Files))
+	}
 
 	var pushOutput struct {
 		push.Output

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Clever/microplane/merge"
 	"github.com/Clever/microplane/plan"
 	"github.com/Clever/microplane/push"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -97,7 +98,7 @@ func getRepoStatus(repo string) (status, details string) {
 	}
 	if !(loadJSON(outputPath(repo, "clone"), &cloneOutput) == nil && cloneOutput.Success) {
 		if cloneOutput.Error != "" {
-			details = "(clone error) " + cloneOutput.Error
+			details = color.RedString("(clone error) ") + cloneOutput.Error
 		}
 		return
 	}
@@ -109,7 +110,7 @@ func getRepoStatus(repo string) (status, details string) {
 	}
 	if !(loadJSON(outputPath(repo, "plan"), &planOutput) == nil && planOutput.Success) {
 		if planOutput.Error != "" {
-			details = "(plan error) " + planOutput.Error
+			details = color.RedString("(plan error) ") + planOutput.Error
 		}
 		return
 	}
@@ -121,7 +122,7 @@ func getRepoStatus(repo string) (status, details string) {
 	}
 	if !(loadJSON(outputPath(repo, "push"), &pushOutput) == nil && pushOutput.Success) {
 		if pushOutput.Error != "" {
-			details = "(push error) " + pushOutput.Error
+			details = color.RedString("(push error) ") + pushOutput.Error
 		}
 		return
 	}
@@ -134,7 +135,7 @@ func getRepoStatus(repo string) (status, details string) {
 	}
 	if !(loadJSON(outputPath(repo, "merge"), &mergeOutput) == nil && mergeOutput.Success) {
 		if mergeOutput.Error != "" {
-			details = "(merge error) " + mergeOutput.Error
+			details = color.RedString("(merge error) ") + mergeOutput.Error
 		}
 		return
 	}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -52,7 +52,7 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 	if err := os.RemoveAll(planDir); err != nil {
 		return Output{Success: false}, fmt.Errorf("could not clear directory %s", planDir)
 	}
-	cmd := exec.CommandContext(ctx, "cp", "-r", "./.", planDir) // "./." copies all the contents of the current directory into the target directory
+	cmd := exec.CommandContext(ctx, "cp", "-a", "./.", planDir) // "./." copies all the contents of the current directory into the target directory
 	cmd.Dir = input.RepoDir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return Output{Success: false}, errors.New(string(output))


### PR DESCRIPTION
Status now

(1) prints errors in red b2d4bb2

![image](https://user-images.githubusercontent.com/102242/34544249-1f3d7730-f09a-11e7-8316-01083adc5568.png)

This helps make errors easier to pick out among all the status output.

(2) shows # of files changed 25357c4

![image](https://user-images.githubusercontent.com/102242/34544261-2d68588e-f09a-11e7-9a05-43598ce22b4e.png)

This is useful in case one repo has a strange number of lines changed. In the long-run, we may want to automatically surface "surprising" diffs (e.g. everything has 1 file change, but some repo has != 1 files changed).

(3) Also includes an unrelated bugfix to copy all files, including symlinks 85c7479 This was an error that would have been easier to catch if we had (2)
  