### PR TITLE
Merge ux improvements

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -34,6 +34,16 @@ var mergeCmd = &cobra.Command{
 func mergeOneRepo(r initialize.Repo, ctx context.Context) error {
 	log.Printf("merging: %s/%s", r.Owner, r.Name)
 
+	// Exit early if already merged
+	var mergeOutput struct {
+		merge.Output
+		Error string
+	}
+	if loadJSON(outputPath(r.Name, "merge"), &mergeOutput) == nil && mergeOutput.Success {
+		log.Printf("already merged: %s/%s", r.Owner, r.Name)
+		return nil
+	}
+
 	// Get previous step's output
 	var pushOutput push.Output
 	if loadJSON(outputPath(r.Name, "push"), &pushOutput) != nil || !pushOutput.Success {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,9 @@ func init() {
 	rootCmd.AddCommand(cloneCmd)
 	rootCmd.AddCommand(docsCmd)
 	rootCmd.AddCommand(initCmd)
+
 	rootCmd.AddCommand(mergeCmd)
+	mergeCmd.Flags().StringVarP(&mergeFlagThrottle, "throttle", "t", "", "Throttle number of merges, e.g. '10s' means 1 merge per 10 seconds")
 
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 
 	rootCmd.AddCommand(mergeCmd)
-	mergeCmd.Flags().StringVarP(&mergeFlagThrottle, "throttle", "t", "", "Throttle number of merges, e.g. '10s' means 1 merge per 10 seconds")
+	mergeCmd.Flags().StringVarP(&mergeFlagThrottle, "throttle", "t", "1ms", "Throttle number of merges, e.g. '30s' means 1 merge per 30 seconds")
 
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -35,7 +35,9 @@ type Error struct {
 }
 
 // Merge an open PR in Github
-func Merge(ctx context.Context, input Input, githubLimiter *time.Ticker) (Output, error) {
+// - githubLimiter rate limits the # of calls to Github
+// - mergeLimiter rate limits # of merges, to prevent load when submitting builds to CI system
+func Merge(ctx context.Context, input Input, githubLimiter *time.Ticker, mergeLimiter *time.Ticker) (Output, error) {
 	// Create Github Client
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: os.Getenv("GITHUB_API_TOKEN")},
@@ -79,6 +81,7 @@ func Merge(ctx context.Context, input Input, githubLimiter *time.Ticker) (Output
 	// Merge the PR
 	options := &github.PullRequestOptions{}
 	commitMsg := ""
+	<-mergeLimiter.C
 	<-githubLimiter.C
 	result, _, err := client.PullRequests.Merge(ctx, input.Org, input.Repo, input.PRNumber, commitMsg, options)
 	if err != nil {

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -52,6 +52,10 @@ func Merge(ctx context.Context, input Input, githubLimiter *time.Ticker) (Output
 		return Output{Success: false}, err
 	}
 
+	if pr.GetMerged() {
+		return Output{Success: true, MergeCommitSHA: pr.GetMergeCommitSHA()}, nil
+	}
+
 	if !pr.GetMergeable() {
 		return Output{Success: false}, fmt.Errorf("PR is not mergeable")
 	}


### PR DESCRIPTION
These UX improvements help make the merge command more responsive by exiting early when possible (d02cbd7) and preventing hammering the CI system via a configurable `--throttle <time>` flag (f384758).

When running my most recent Microplane change, I used `--throttle 60s` to ensure I wasn't merging too quickly and hammering CI during working hours.
