### PR TITLE
Before merging, require PR approval (allow override)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "a021c14a5f1960591b0e1773a4a2ef8257ec93b8"
+  revision = "922ceac0585d40f97d283d921f872fc50480e06e"
 
 [[projects]]
   branch = "master"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ func init() {
 
 	rootCmd.AddCommand(mergeCmd)
 	mergeCmd.Flags().StringVarP(&mergeFlagThrottle, "throttle", "t", "1ms", "Throttle number of merges, e.g. '30s' means 1 merge per 30 seconds")
+	mergeCmd.Flags().BoolVar(&mergeFlagIgnoreReviewApproval, "ignore-review-approval", false, "Ignore whether or not the review has been approved")
 
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -145,6 +145,7 @@ func getRepoStatus(repo string) (status, details string) {
 		return
 	}
 	status = "merged"
+	details = ""
 
 	return
 }


### PR DESCRIPTION
Previously, `merge` checked if a PR was mergeable (no rebase needed) and
also inspected its github status (e.g. "are unit tests passing via CI?")

Now, `merge `also inspects whether 1 or more reviewers has accepted
the PR. You can override this check by passing

```
mp merge --ignore-review-approval
```