### PR TITLE
allow throttling push

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -19,7 +19,7 @@ import (
 var mergeFlagThrottle string
 var mergeFlagIgnoreReviewApproval bool
 
-// rate limits the # of PR merges per duration. used to prevent load on CI system
+// rate limits the # of PR merges. used to prevent load on CI system
 var mergeThrottle *time.Ticker
 
 var mergeCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ func init() {
 	planCmd.Flags().StringVarP(&planFlagMessage, "message", "m", "", "Commit message")
 
 	rootCmd.AddCommand(pushCmd)
+	pushCmd.Flags().StringVarP(&pushFlagThrottle, "throttle", "t", "1ms", "Throttle number of pushes, e.g. '30s' means 1 push per 30 seconds")
 	pushCmd.Flags().StringVarP(&pushFlagAssignee, "assignee", "a", "", "Github user to assign the PR to")
 
 	rootCmd.AddCommand(statusCmd)


### PR DESCRIPTION
this can be used to prevent pushing commits too aggressively and overwhelming CI

we already support throttling for `mp merge`, so I copied that approach here