### PR TITLE
Add flag to ignore build status when merging

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -18,6 +18,7 @@ import (
 // CLI flags
 var mergeFlagThrottle string
 var mergeFlagIgnoreReviewApproval bool
+var mergeFlagIgnoreBuildStatus bool
 
 // rate limits the # of PR merges. used to prevent load on CI system
 var mergeThrottle *time.Ticker
@@ -91,6 +92,7 @@ func mergeOneRepo(r initialize.Repo, ctx context.Context) error {
 		PRNumber:              prNumber,
 		CommitSHA:             pushOutput.CommitSHA,
 		RequireReviewApproval: !mergeFlagIgnoreReviewApproval,
+		RequireBuildSuccess:   !mergeFlagIgnoreBuildStatus,
 	}
 	output, err := merge.Merge(ctx, input, githubLimiter, mergeThrottle)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ func init() {
 	rootCmd.AddCommand(mergeCmd)
 	mergeCmd.Flags().StringVarP(&mergeFlagThrottle, "throttle", "t", "1ms", "Throttle number of merges, e.g. '30s' means 1 merge per 30 seconds")
 	mergeCmd.Flags().BoolVar(&mergeFlagIgnoreReviewApproval, "ignore-review-approval", false, "Ignore whether or not the review has been approved")
+	mergeCmd.Flags().BoolVar(&mergeFlagIgnoreBuildStatus, "ignore-build-status", false, "Ignore whether or not builds are passing")
 
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -24,6 +24,8 @@ type Input struct {
 	// - must have at least 1 reviewer
 	// - all reviewers must have explicitly approved
 	RequireReviewApproval bool
+	// RequireBuildSuccess specifies if the PR must have a successful build before merging
+	RequireBuildSuccess bool
 }
 
 // Output from Push()
@@ -74,9 +76,11 @@ func Merge(ctx context.Context, input Input, githubLimiter *time.Ticker, mergeLi
 		return Output{Success: false}, err
 	}
 
-	state := status.GetState()
-	if state != "success" {
-		return Output{Success: false}, fmt.Errorf("status was not 'success', instead was '%s'", state)
+	if input.RequireBuildSuccess {
+		state := status.GetState()
+		if state != "success" {
+			return Output{Success: false}, fmt.Errorf("status was not 'success', instead was '%s'", state)
+		}
 	}
 
 	// (3) check if PR has been approved by a reviewer


### PR DESCRIPTION
Without this flag it is impossible to automatically merge PRs for repos without some kind of CI. 