### PR TITLE
add gitlab integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,25 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/microplane
     docker:
-    - image: circleci/golang:1.12-stretch
+      - image: circleci/golang:1.12-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-    - run:
-        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-        name: Clone ci-scripts
-    - checkout
-    - run:
-        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-        name: Set up CircleCI artifacts directories
-    - run: make install_deps
-    - run: make build
-    - run:
-        command: make test
-        environment:
-          GITHUB_API_TOKEN: x
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;
+      - run:
+          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+          name: Clone ci-scripts
+      - checkout
+      - run:
+          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+          name: Set up CircleCI artifacts directories
+      - run: make install_deps
+      - run: make build
+      - run:
+          command: make test
+          environment:
+            GITHUB_API_TOKEN: x
+            GITLAB_API_TOKEN: "" # both cannot be set
+      - run:
+          command: ./gitlab_integration_test.sh
+      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "8e:93:7e:53:e8:0e:72:4f:f1:9c:0f:50:66:55:5e:f1" # GitLab
       - run:
           command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
           name: Clone ci-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,5 +23,5 @@ jobs:
             GITHUB_API_TOKEN: x
             GITLAB_API_TOKEN: "" # both cannot be set
       - run:
-          command: ./gitlab_integration_test.sh
+          command: ssh-keyscan -H gitlab.com >> ~/.ssh/known_hosts && ./gitlab_integration_test.sh
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;

--- a/gitlab_integration_test.sh
+++ b/gitlab_integration_test.sh
@@ -1,0 +1,38 @@
+set -e
+
+t="Verify Microplane commands work e2e on GitLab"
+
+echo "== START: ($t) =="
+
+echo ""
+echo "init"
+echo ""
+
+./bin/mp init "mp-test-1"
+
+echo ""
+echo "clone"
+echo ""
+
+./bin/mp clone
+
+echo ""
+echo "plan"
+echo ""
+
+./bin/mp plan -b test1 -m "test1" -- touch test-$(date +"%T").txt
+
+echo ""
+echo "push"
+echo ""
+
+./bin/mp push -a microplane-gitlab
+
+echo ""
+echo "merge"
+echo ""
+
+./bin/mp merge --ignore-build-status
+
+echo ""
+echo "== END: ($t) =="


### PR DESCRIPTION
_blocker_: GitLab suggested using ED25519 key, but not supported to add to CircleCI build environment. 

- https://discuss.circleci.com/t/circleci-says-my-ed25519-private-key-is-invalid/25807
- https://ideas.circleci.com/ideas/CCI-I-242

Will explore workarounds or transition to a different key type for this test automation.
