### PR TITLE
allow init from file

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,15 +10,31 @@ import (
 )
 
 var repoProviderFlag string
+var initFlagReposFile string
 
 var initCmd = &cobra.Command{
 	Use:   "init [query]",
 	Short: "Initialize a microplane workflow",
 	Long: `Initialize a microplane workflow.
 
-## GitHub
+There are two ways to init, either (1) from a file or (2) via search
 
-It targets repos based on a Github Code Search query. For example
+## (1) Init from File
+
+$ mp init -f repos.txt
+
+where repos.txt has lines like:
+
+	clever/repo2
+	clever/repo2
+
+## (2) Init via Search
+
+### GitHub
+
+Search targets repos based on a Github Code Search query.
+
+For example:
 
 $ mp init "org:Clever filename:circle.yml"
 
@@ -26,25 +42,40 @@ would target all Clever repos with a circle.yml file.
 
 See https://help.github.com/articles/searching-code/ for more details about the search syntax on Github.
 
-## GitLab
+### GitLab
 
-If you are using the public version of GitLab, search is done via the Global "projects" scope.
+Search targets repos based on a GitLab search.
+
+If you are using the *public* version of GitLab, search is done via the Global "projects" scope.
 See https://docs.gitlab.com/ce/api/search.html#scope-projects for more information on the search syntax. For example
 
 $ mp init "mp-test-1"
 
 would target a specific repo called mp-test-1.
 
-If you are using an enterprise GitLab instance, we assume you have an ElasticSearch setup.
+If you are using an *enterprise* GitLab instance, we assume you have an ElasticSearch setup.
 See https://docs.gitlab.com/ee/user/search/advanced_search_syntax.html for more details about the search syntax on Gitlab.`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
-		query := args[0]
+		if len(args) == 0 && initFlagReposFile == "" {
+			log.Fatal("to init via search, you must pass a search query. otherwise, specify a repos file with -f")
+		}
+
+		if len(args) == 1 && initFlagReposFile != "" {
+			log.Fatal("to init via search, you must pass a search query. otherwise, specify a repos file with -f")
+		}
+
+		query := ""
+		if len(args) > 0 {
+			query = args[0]
+		}
+
 		output, err := initialize.Initialize(initialize.Input{
-			Query:        query,
-			WorkDir:      workDir,
-			Version:      cliVersion,
-			RepoProvider: repoProviderFlag,
+			Query:         query,
+			WorkDir:       workDir,
+			Version:       cliVersion,
+			RepoProvider:  repoProviderFlag,
+			ReposFromFile: initFlagReposFile,
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,8 +58,12 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 
 	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().StringVarP(&initFlagReposFile, "file", "f", "", "get repos from a file instead of searching")
 
-	workDir, _ = filepath.Abs("./mp")
+	workDir, err := filepath.Abs("./mp")
+	if err != nil {
+		log.Fatalf("error finding workDir: %s\n", err.Error())
+	}
 
 	// Create workDir, if doesn't yet exist
 	if _, err := os.Stat(workDir); os.IsNotExist(err) {


### PR DESCRIPTION
Previously, we required the user to do a GitHub (or GitLab) search to
generate the initial list of repos.

What if you... already know... the repos you want to target? :)
The previous UX was actually more painful.

This should make it easier to just declare your repo list and move on.