### PR TITLE
search repos not code

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,6 +11,7 @@ import (
 
 var repoProviderFlag string
 var initFlagReposFile string
+var repoSearchQuery string
 
 var initCmd = &cobra.Command{
 	Use:   "init [query]",
@@ -30,7 +31,7 @@ where repos.txt has lines like:
 
 ## (2) Init via Search
 
-### GitHub
+### GitHub Code Search
 
 Search targets repos based on a Github Code Search query.
 
@@ -41,6 +42,22 @@ $ mp init "org:Clever filename:circle.yml"
 would target all Clever repos with a circle.yml file.
 
 See https://help.github.com/articles/searching-code/ for more details about the search syntax on Github.
+
+### Github Repo Search
+
+Search targets repos based on a Github Repo Search query.
+
+For example:
+
+$ mp init -rs "org:Clever"
+
+would target all Clever repos in clever org.
+
+$ mp init -rs "org:Clever language:Go"
+
+would target all Clever repos written in Go
+
+See https://help.github.com/articles/searching-repositories/ for more details about the search syntax on Github.
 
 ### GitLab
 
@@ -58,11 +75,18 @@ See https://docs.gitlab.com/ee/user/search/advanced_search_syntax.html for more 
 	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 && initFlagReposFile == "" {
-			log.Fatal("to init via search, you must pass a search query. otherwise, specify a repos file with -f")
+			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
+				"If init with a github repo search, specify a query after -rs.")
 		}
 
 		if len(args) == 1 && initFlagReposFile != "" {
-			log.Fatal("to init via search, you must pass a search query. otherwise, specify a repos file with -f")
+			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
+				"If init with a github repo search, specify a query after -rs.")
+		}
+
+		if len(args) == 1 && repoSearchQuery != "" {
+			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
+				"If init with a github repo search, specify a query after -rs.")
 		}
 
 		query := ""
@@ -71,11 +95,12 @@ See https://docs.gitlab.com/ee/user/search/advanced_search_syntax.html for more 
 		}
 
 		output, err := initialize.Initialize(initialize.Input{
-			Query:         query,
-			WorkDir:       workDir,
-			Version:       cliVersion,
-			RepoProvider:  repoProviderFlag,
-			ReposFromFile: initFlagReposFile,
+			Query:           query,
+			WorkDir:         workDir,
+			Version:         cliVersion,
+			RepoProvider:    repoProviderFlag,
+			ReposFromFile:   initFlagReposFile,
+			RepoSearchQuery: repoSearchQuery,
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,7 +11,7 @@ import (
 
 var repoProviderFlag string
 var initFlagReposFile string
-var repoSearchQuery string
+var repoSearch bool
 
 var initCmd = &cobra.Command{
 	Use:   "init [query]",
@@ -33,7 +33,7 @@ where repos.txt has lines like:
 
 ### GitHub Code Search
 
-Search targets repos based on a Github Code Search query.
+- Search target repos based on a Github Code Search query.
 
 For example:
 
@@ -45,15 +45,15 @@ See https://help.github.com/articles/searching-code/ for more details about the 
 
 ### Github Repo Search
 
-Search targets repos based on a Github Repo Search query.
+- Search target repos based on a Github Repo Search query.
 
 For example:
 
-$ mp init -s "org:Clever"
+$ mp init "org:Clever" --repo-search
 
 would target all Clever repos in clever org.
 
-$ mp init -s "org:Clever language:Go"
+$ mp init "org:Clever language:Go" --repo-search
 
 would target all Clever repos written in Go
 
@@ -61,7 +61,7 @@ See https://help.github.com/articles/searching-repositories/ for more details ab
 
 ### GitLab
 
-Search targets repos based on a GitLab search.
+Search target repos based on a GitLab search.
 
 If you are using the *public* version of GitLab, search is done via the Global "projects" scope.
 See https://docs.gitlab.com/ce/api/search.html#scope-projects for more information on the search syntax. For example
@@ -76,17 +76,12 @@ See https://docs.gitlab.com/ee/user/search/advanced_search_syntax.html for more 
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 && initFlagReposFile == "" {
 			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
-				"If init with a github repo search, specify a query after -rs.")
+				"If init with a github repo search, include --repo-search flag.")
 		}
 
 		if len(args) == 1 && initFlagReposFile != "" {
 			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
-				"If init with a github repo search, specify a query after -rs.")
-		}
-
-		if len(args) == 1 && repoSearchQuery != "" {
-			log.Fatal("to init via code search (default), you must pass a search query. If init from a repo file, specify a repos file with -f." +
-				"If init with a github repo search, specify a query after -rs.")
+				"If init with a github repo search, include --repo-search flag.")
 		}
 
 		query := ""
@@ -95,12 +90,12 @@ See https://docs.gitlab.com/ee/user/search/advanced_search_syntax.html for more 
 		}
 
 		output, err := initialize.Initialize(initialize.Input{
-			Query:           query,
-			WorkDir:         workDir,
-			Version:         cliVersion,
-			RepoProvider:    repoProviderFlag,
-			ReposFromFile:   initFlagReposFile,
-			RepoSearchQuery: repoSearchQuery,
+			Query:         query,
+			WorkDir:       workDir,
+			Version:       cliVersion,
+			RepoProvider:  repoProviderFlag,
+			ReposFromFile: initFlagReposFile,
+			RepoSearch:    repoSearch,
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,11 +49,11 @@ Search targets repos based on a Github Repo Search query.
 
 For example:
 
-$ mp init -rs "org:Clever"
+$ mp init -s "org:Clever"
 
 would target all Clever repos in clever org.
 
-$ mp init -rs "org:Clever language:Go"
+$ mp init -s "org:Clever language:Go"
 
 would target all Clever repos written in Go
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVarP(&initFlagReposFile, "file", "f", "", "get repos from a file instead of searching")
-	initCmd.Flags().StringVarP(&repoSearchQuery, "repo-search", "rs", "", "get repos from a github repo search")
+	initCmd.Flags().StringVarP(&repoSearchQuery, "repo-search", "s", "", "get repos from a github repo search")
 
 	var err error
 	workDir, err = filepath.Abs("./mp")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVarP(&initFlagReposFile, "file", "f", "", "get repos from a file instead of searching")
-	initCmd.Flags().StringVarP(&repoSearchQuery, "repo-search", "s", "", "get repos from a github repo search")
+	initCmd.Flags().BoolVar(&repoSearch, "repo-search", false, "get repos from a github repo search")
 
 	var err error
 	workDir, err = filepath.Abs("./mp")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVarP(&initFlagReposFile, "file", "f", "", "get repos from a file instead of searching")
+	initCmd.Flags().StringVarP(&repoSearchQuery, "repo-search", "rs", "", "get repos from a github repo search")
 
 	var err error
 	workDir, err = filepath.Abs("./mp")

--- a/docs/mp_init.md
+++ b/docs/mp_init.md
@@ -53,8 +53,9 @@ mp init [query] [flags]
 ### Options
 
 ```
-  -f, --file string   get repos from a file instead of searching
-  -h, --help          help for init
+  -f, --file         string   get repos from a file instead of searching
+  -h, --help                  help for init
+  -rs, --repo-search string   get repos from a github repo search
 ```
 
 ### Options inherited from parent commands

--- a/docs/mp_init.md
+++ b/docs/mp_init.md
@@ -55,7 +55,7 @@ mp init [query] [flags]
 ```
   -f, --file         string   get repos from a file instead of searching
   -h, --help                  help for init
-  -rs, --repo-search string   get repos from a github repo search
+  -s, --repo-search  string   get repos from a github repo search
 ```
 
 ### Options inherited from parent commands

--- a/docs/mp_init.md
+++ b/docs/mp_init.md
@@ -22,7 +22,7 @@ where repos.txt has lines like:
 
 ### GitHub
 
-Search targets repos based on a Github Code Search query.
+- Search target repos based on a Github Code Search query.
 
 For example:
 
@@ -32,9 +32,23 @@ would target all Clever repos with a circle.yml file.
 
 See https://help.github.com/articles/searching-code/ for more details about the search syntax on Github.
 
+- Search target repos based on a Github Repo Search query.
+
+For exampel:
+
+$mp init "org:Clever" --repo-search
+
+would target all Clever repos
+
+$ mp init "org:Clever language:Go" --repo-search
+
+would target all Clever repos written in Go
+
+See https://help.github.com/articles/searching-repositories/ for more details about the search syntax on Github.
+
 ### GitLab
 
-Search targets repos based on a GitLab search.
+Search target repos based on a GitLab search.
 
 If you are using the *public* version of GitLab, search is done via the Global "projects" scope.
 See https://docs.gitlab.com/ce/api/search.html#scope-projects for more information on the search syntax. For example
@@ -55,7 +69,7 @@ mp init [query] [flags]
 ```
   -f, --file         string   get repos from a file instead of searching
   -h, --help                  help for init
-  -s, --repo-search  string   get repos from a github repo search
+  --repo-search      bool     get repos from a github repo search
 ```
 
 ### Options inherited from parent commands

--- a/initialize/initialize.go
+++ b/initialize/initialize.go
@@ -25,12 +25,12 @@ type Repo struct {
 
 // Input for Initialize
 type Input struct {
-	WorkDir         string
-	Query           string
-	Version         string
-	RepoProvider    string
-	ReposFromFile   string
-	RepoSearchQuery string
+	WorkDir       string
+	Query         string
+	Version       string
+	RepoProvider  string
+	ReposFromFile string
+	RepoSearch    bool
 }
 
 // Output for Initialize
@@ -53,9 +53,9 @@ func Initialize(input Input) (Output, error) {
 	if input.ReposFromFile != "" {
 		// Read repos from file
 		repos, err = reposFromFile(input)
-	} else if input.RepoSearchQuery != "" {
+	} else if input.RepoSearch {
 		// Do search with Repo type only
-		repos, err = githubRepoSearch(input.RepoSearchQuery)
+		repos, err = githubRepoSearch(input.Query)
 	} else {
 		// Do code search
 		if input.RepoProvider == "github" {

--- a/initialize/initialize.go
+++ b/initialize/initialize.go
@@ -133,7 +133,7 @@ func githubSearch(query string) ([]Repo, error) {
 	allRepos := map[string]*github.Repository{}
 	numProcessedResults := 0
 	for {
-		result, resp, err := client.Search.Code(context.Background(), query, opts)
+		result, resp, err := client.Search.Repositories(context.Background(), query, opts)
 		if abuseErr, ok := err.(*github.AbuseRateLimitError); ok {
 			var waitTime time.Duration
 			if abuseErr.RetryAfter != nil {
@@ -148,10 +148,9 @@ func githubSearch(query string) ([]Repo, error) {
 			return []Repo{}, err
 		}
 
-		for _, codeResult := range result.CodeResults {
+		for _, repoResult := range result.Repositories {
 			numProcessedResults = numProcessedResults + 1
-			repoCopy := *codeResult.Repository
-			allRepos[*codeResult.Repository.Name] = &repoCopy
+			allRepos[*repoResult.Name] = &repoResult
 		}
 
 		incompleteResults := result.GetIncompleteResults()


### PR DESCRIPTION
## Link to JIRA
[Link to JIRA](https://clever.atlassian.net/browse/IL-2090)

## Overview
Currently `mp init` command searches code, not repositories. In this PR, I change the code from searching code -> repos.

## Testing
I don't see an easy way to test the change except from merging it and trying it with 1 script.