### PR TITLE
Fixes --body-file flag usage

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -107,15 +107,13 @@ func GithubPush(ctx context.Context, input Input, repoLimiter *time.Ticker, push
 
 	// Determine PR title and body
 	// Title is first line of commit message.
-	// Body is given by body-file if it exists or is the remainder of the commit message after title.
+	// Body is the remainder of the commit message after title AND/OR `body-file` content if given
 	title := input.CommitMessage
-	body := ""
+	body := input.PRBody
 	splitMsg := strings.SplitN(input.CommitMessage, "\n", 2)
 	if len(splitMsg) == 2 {
 		title = splitMsg[0]
-		if input.PRBody == "" {
-			body = splitMsg[1]
-		}
+		body = splitMsg[1] + "\n" + input.PRBody
 	}
 	pr, err := findOrCreatePR(ctx, client, input.RepoOwner, input.RepoName, &github.NewPullRequest{
 		Title: &title,


### PR DESCRIPTION
## Info
This fixes the issue with `--body-file` as was brought up in #57, but with the additional request from maintainer to update the body to be a combination of the commit message + body-file content if both are given.

Closes #57 

## Overview
- [ ] Bumped up the version in VERSION file

## Testing
- I wasn't able to test or build locally unfortunately. `make test` returned the following for me:

```
FORMATTING _/Users/gowiem/Workspace/Cloned/microplane...
stat /Users/gowiem/Workspace/go/src/_/Users/gowiem/Workspace/Cloned/microplane/*.go: no such file or directory
error running command: exit status 2
make: *** [_/Users/gowiem/Workspace/Cloned/microplane] Error 1
```

