### PR TITLE
chore(deps): upgrade to go1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/microplane
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: circleci/golang:1.15-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include golang.mk
 PKGS := $(shell go list ./... | grep -v vendor)
 VERSION := $(shell head -n 1 VERSION)
 EXECUTABLE := mp
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.15))
 
 $(GOPATH)/bin/dep:
 	@go get github.com/golang/dep


### PR DESCRIPTION
Bump to go 1.15

relates to https://github.com/Homebrew/homebrew-core/pull/59749