### PR TITLE
golang:1.15-stretch dne. use -buster instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/microplane
     docker:
-    - image: circleci/golang:1.15-stretch
+    - image: circleci/golang:1.15-buster
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results


### PR DESCRIPTION
fixup for #61 

Looks like Debian Stretch was superseded by Debian Buster on 2019-07-06
https://wiki.debian.org/DebianStretch

https://hub.docker.com/layers/circleci/golang/1.15-buster/images/sha256-2930f56c9f5973254c37e329d476e639a8ac1d4672eea042716b1182dbe1485f?context=explore