### PR TITLE
Parallelism limit added for plan command

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -28,11 +28,15 @@ func writeJSON(obj interface{}, path string) error {
 	return ioutil.WriteFile(path, b, 0644)
 }
 
-// parallelize take a list of repos and applies a function (clone, plan, ...) to them
 func parallelize(repos []initialize.Repo, f func(initialize.Repo, context.Context) error) error {
+    return parallelizeLimited(repos, f, 10)
+}
+
+// parallelize take a list of repos and applies a function (clone, plan, ...) to them
+func parallelizeLimited(repos []initialize.Repo, f func(initialize.Repo, context.Context) error, parallelismLimit int64) error {
 	ctx := context.Background()
 	var eg errgroup.Group
-	parallelLimit := semaphore.NewWeighted(10)
+	parallelLimit := semaphore.NewWeighted(parallelismLimit)
 	for _, r := range repos {
 		eg.Add(1)
 		go func(repo initialize.Repo) {

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -17,6 +17,7 @@ import (
 
 var planFlagBranch string
 var planFlagMessage string
+var planFlagParallelism int64
 
 // TODO: Pass these *not* via globals
 // these variables are set when the cmd starts running
@@ -36,6 +37,7 @@ var planCmd = &cobra.Command{
 mp plan -b microplaning -m 'microplane fun' -r app-service -- python /absolute/path/to/script`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
+        var parallelismLimit int64
 
 		changeCmd = args[0]
 		if len(args) > 1 {
@@ -64,7 +66,9 @@ mp plan -b microplaning -m 'microplane fun' -r app-service -- python /absolute/p
 		}
 		isSingleRepo = len(repos) == 1
 
-		err = parallelize(repos, planOneRepo)
+        parallelismLimit, err = cmd.Flags().GetInt64("parallelism")
+	    log.Printf("planning %d repos with parallelism limit [%d]", len(repos), parallelismLimit)
+		err = parallelizeLimited(repos, planOneRepo, parallelismLimit)
 		if err != nil {
 			log.Fatalf("%d errors:\n %+v\n", strings.Count(err.Error(), " | ")+1, err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 var workDir string
 var cliVersion string
+var defaultParallelism int64 = 10
 
 // Github's rate limit for authenticated requests is 5000 QPH = 83.3 QPM = 1.38 QPS = 720ms/query
 // We also use a global limiter to prevent concurrent requests, which trigger Github's abuse detection
@@ -49,6 +50,7 @@ func init() {
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")
 	planCmd.Flags().StringVarP(&planFlagMessage, "message", "m", "", "Commit message")
+	planCmd.Flags().Int64VarP(&planFlagParallelism, "parallelism", "p", defaultParallelism, "Parallelism limit")
 
 	rootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().StringVarP(&pushFlagThrottle, "throttle", "t", "30s", "Throttle number of pushes, e.g. '30s' means 1 push per 30 seconds")

--- a/docs/mp_plan.md
+++ b/docs/mp_plan.md
@@ -24,6 +24,7 @@ mp plan -b microplaning -m 'microplane fun' -r app-service -- python /absolute/p
   -b, --branch string    Git branch to commit to
   -h, --help             help for plan
   -m, --message string   Commit message
+  -p, --parallelism int  Parallelism limit (default 10)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Overview
- Parallelism limit added for `plan` command. Useful if your script for plan is not working in parallel (just set parallelism limit to 1)