### PR TITLE
Support Github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Here are several ways to install microplane:
 
 The `GITHUB_API_TOKEN` environment variable must be set for Github. This should be a [GitHub Token](https://github.com/settings/tokens) with `repo` scope.
 
-### GitLab setup
+Optional: If you use self-hosted Github, you can specify its URL by passing `--provider_url=<your URL>` when running `mp init`.
+This URL should look like: `https://[hostname]`. Don't include path parameters like `/api/v3` or `/api/uploads`.
 
+_Self-hosted Github setup with different URLs for the main API and uploads API are not yet supported. If this is a blocker for you, please file an issue or make a PR._
+
+### GitLab setup
 
 The `GITLAB_API_TOKEN` environment variable must be set for Gitlab. This should be a [GitLab access token](https://gitlab.com/profile/personal_access_tokens)
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -39,9 +39,14 @@ func cloneOneRepo(r lib.Repo, ctx context.Context) error {
 	}
 
 	// Execute
+	cloneURL, err := r.ComputedCloneURL()
+	if err != nil {
+		return err
+	}
+
 	input := clone.Input{
 		WorkDir: cloneWorkDir,
-		GitURL:  r.CloneURL,
+		GitURL:  cloneURL,
 	}
 	output, err := clone.Clone(ctx, input)
 	if err != nil {

--- a/initialize/initialize.go
+++ b/initialize/initialize.go
@@ -116,7 +116,6 @@ func reposFromFile(p *lib.Provider, file string) ([]lib.Repo, error) {
 		repos = append(repos, lib.Repo{
 			Owner:          parts[0],
 			Name:           parts[1],
-			CloneURL:       fmt.Sprintf("%s:%s", p.CloneURLPrefix(), item),
 			ProviderConfig: p.ProviderConfig,
 		})
 	}
@@ -267,7 +266,6 @@ func getFormattedRepos(p *lib.Provider, allRepos map[string]*github.Repository) 
 		formattedRepos = append(formattedRepos, lib.Repo{
 			Name:           r.GetName(),
 			Owner:          r.Owner.GetLogin(),
-			CloneURL:       fmt.Sprintf("git@github.com:%s", r.GetFullName()),
 			ProviderConfig: p.ProviderConfig,
 		})
 	}

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -48,8 +48,10 @@ func (p *Provider) GithubClient(ctx context.Context) (*github.Client, error) {
 	// create the client
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(ctx, ts)
+	if p.IsEnterprise() {
+		return github.NewEnterpriseClient(p.BackendURL, p.BackendURL, tc)
+	}
 	client := github.NewClient(tc)
-
 	return client, nil
 }
 

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -20,10 +20,6 @@ func (pc ProviderConfig) IsEnterprise() bool {
 	return pc.BackendURL != ""
 }
 
-func (pc ProviderConfig) CloneURLPrefix() string {
-	return fmt.Sprintf("git@%s.com", pc.Backend)
-}
-
 // Provider is an abstraction over a Git provider (Github, Gitlab, etc)
 type Provider struct {
 	ProviderConfig

--- a/lib/repo.go
+++ b/lib/repo.go
@@ -1,10 +1,15 @@
 package lib
 
+import (
+	"fmt"
+	"net/url"
+)
+
 // Repo describes a git Repository with a given Provider
 type Repo struct {
 	Name     string
 	Owner    string
-	CloneURL string // TODO: someday, compute this from ProviderConfig
+	CloneURL string // consider if we can remove this. ComputedCloneURL is a first step
 	ProviderConfig
 }
 
@@ -14,4 +19,22 @@ func (r Repo) IsGithub() bool {
 
 func (r Repo) IsGitlab() bool {
 	return r.ProviderConfig.Backend == "gitlab"
+}
+
+func (r Repo) ComputedCloneURL() (string, error) {
+	// If we saved a CloneURL retrieved from provider's API, use that
+	if r.CloneURL != "" {
+		return r.CloneURL, nil
+	}
+
+	// Otherwise, make our best guess!
+	hostname := fmt.Sprintf("%s.com", r.ProviderConfig.Backend)
+	if r.ProviderConfig.IsEnterprise() {
+		parsed, err := url.Parse(r.ProviderConfig.BackendURL)
+		if err != nil {
+			return "", err
+		}
+		hostname = parsed.Hostname()
+	}
+	return fmt.Sprintf("git@%s:%s/%s", hostname, r.Owner, r.Name), nil
 }


### PR DESCRIPTION
## JIRA
n/a

## Overview
Allows microplane to work with Github enterprise.

Caveat noted in README: _Self-hosted Github setup with different URLs for the main API and uploads API are not yet supported. If this is a blocker for you, please file an issue or make a PR._ 

## Testing
- [ ] Test e2e with a Github enterprise setup :octocat: 💰 
- [x] Test e2e with normal Github setup :octocat: to verify no regressions
