### PR TITLE
Add version subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,8 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 
+	rootCmd.AddCommand(versionCmd)
+
 	var err error
 	workDir, err = filepath.Abs("./mp")
 	if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the current microplane version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("microplane", cliVersion)
+	},
+}


### PR DESCRIPTION
## Overview
Adds a `version` subcommand so users can check the current version. 

And this is very much baby's first Golang contribution, so let me know if there's anything I should fix, or any wording tweaks :+1: 

## Testing
Confirmed that it works:
```
> mp version
microplane 0.0.30
```

And that `--help` gives the right description:
```
> mp version --help
Print the current microplane version

Usage:
  mp version [flags]

Flags:
  -h, --help   help for version

Global Flags:
  -r, --repo string   single repo to operate on
```
