### PR TITLE
Add a `--diff` flag to `mp plan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # changelog
 
+unreleased - v0.0.32
+
+- Adds - `--diff` flag added to `mp plan` to show the diff of the changes made in each repo
+- Changes - `mp plan` no longer shows the diff for a single repo by default
+
 2021-05-15 - v0.0.31
 
 - Adds - `--draft` flag added to `mp push`, to create a draft Pull Request

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -16,6 +16,7 @@ import (
 )
 
 var planFlagBranch string
+var planFlagDiff bool
 var planFlagMessage string
 var planFlagParallelism int64
 
@@ -27,6 +28,7 @@ var (
 	changeCmd     string
 	changeCmdArgs []string
 	isSingleRepo  bool
+	showDiff      bool
 )
 
 var planCmd = &cobra.Command{
@@ -51,6 +53,12 @@ mp plan -b microplaning -m 'microplane fun' -r app-service -- python /absolute/p
 		if branchName == "" {
 			log.Fatal("--branch is required")
 		}
+
+		diff, err := cmd.Flags().GetBool("diff")
+		if err != nil {
+			log.Fatal(err)
+		}
+		showDiff = diff
 
 		commitMessage, err = cmd.Flags().GetString("message")
 		if err != nil {
@@ -124,7 +132,8 @@ func planOneRepo(r lib.Repo, ctx context.Context) error {
 		return fmt.Errorf("%s/%s error: %+v", r.Owner, r.Name, err)
 	}
 	writeJSON(output, planOutputPath)
-	if isSingleRepo {
+	if showDiff {
+		log.Printf("diffing: %s/%s", r.Owner, r.Name)
 		fmt.Println(output.GitDiff)
 	}
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ func init() {
 
 	rootCmd.AddCommand(planCmd)
 	planCmd.Flags().StringVarP(&planFlagBranch, "branch", "b", "", "Git branch to commit to")
+	planCmd.Flags().BoolVarP(&planFlagDiff, "diff", "d", false, "Show the diffs of the changes made per repo")
 	planCmd.Flags().StringVarP(&planFlagMessage, "message", "m", "", "Commit message")
 	planCmd.Flags().Int64VarP(&planFlagParallelism, "parallelism", "p", defaultParallelism, "Parallelism limit")
 

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -30,6 +30,8 @@ type Input struct {
 	CommitMessage string
 	// BranchName where the commit will be made
 	BranchName string
+	// Whether to display the diff of changes made
+	Diff bool
 }
 
 // Output for Plan


### PR DESCRIPTION
## Overview
_Give a high level description of your changes._

I've found I often like seeing the diffs of all changes made in all repos, but currently `plan` only shows the diff if there's just one repo (which is understandable, to not spew page after page of diffs by default).

This adds a `--diff` flag to optionally show all diffs, separated by repo with a `diffing: org/repo` message before each diff.

Now that there's a flag to show diffs, I removed the previous default action of showing a diff if there's just one repo being worked with. I thought the user might find it unexpected to see a diff without explicitly setting the diff flag (let me know if I should keep that in there though).

## Testing
_Describe testing you did to ensure your changes work and that existing functionality was not broken by the changes._

Tested with a single repo (first without the diff flag, and then with):

![Screenshot from 2021-05-22 02-12-27](https://user-images.githubusercontent.com/7545665/119217062-aecd6a80-baa5-11eb-85ef-d576c99f9a39.png)

And with 3 repos (without diff, and then with diff):

![Screenshot from 2021-05-22 02-19-43](https://user-images.githubusercontent.com/7545665/119216911-885aff80-baa4-11eb-8c21-eb9646e0df4f.png)
