### PR TITLE
Updates to Gitlab PRs

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -109,16 +109,7 @@ func GithubPush(ctx context.Context, input Input, repoLimiter *time.Ticker, push
 	}
 	base := *repository.DefaultBranch
 
-	// Determine PR title and body
-	// Title is first line of commit message.
-	// Body is the remainder of the commit message after title AND/OR `body-file` content if given
-	title := input.CommitMessage
-	body := input.PRBody
-	splitMsg := strings.SplitN(input.CommitMessage, "\n", 2)
-	if len(splitMsg) == 2 {
-		title = splitMsg[0]
-		body = splitMsg[1] + "\n" + input.PRBody
-	}
+	title, body := getTitleBody(input)
 	pr, err := findOrCreatePR(ctx, client, input.Repo.Owner, input.Repo.Name, &github.NewPullRequest{
 		Title: &title,
 		Body:  &body,
@@ -219,4 +210,20 @@ func findOrCreatePR(ctx context.Context, client *github.Client, owner string, na
 
 func different(s1, s2 *string) bool {
 	return s1 != nil && s2 != nil && *s1 != *s2
+}
+
+// Determine PR title and body
+// Title is first line of commit message.
+// Body is the remainder of the commit message after title AND/OR `body-file` content if given
+func getTitleBody(input Input) (string, string) {
+	title := input.CommitMessage
+	body := input.PRBody
+
+	splitMsg := strings.SplitN(input.CommitMessage, "\n", 2)
+	if len(splitMsg) == 2 {
+		title = splitMsg[0]
+		body = splitMsg[1] + "\n" + input.PRBody
+	}
+
+	return title, body
 }

--- a/push/pushGitlab.go
+++ b/push/pushGitlab.go
@@ -48,19 +48,7 @@ func GitlabPush(ctx context.Context, input Input, repoLimiter *time.Ticker, push
 	head := input.BranchName
 	base := project.DefaultBranch
 
-	// Determine MR title and body
-	// Title is first line of commit message.
-	// Body is given by body-file if it exists or is the remainder of the commit message after title.
-	title := input.CommitMessage
-	body := ""
-	splitMsg := strings.SplitN(input.CommitMessage, "\n", 2)
-	if len(splitMsg) == 2 {
-		title = splitMsg[0]
-		if input.PRBody == "" {
-			body = splitMsg[1]
-		}
-	}
-
+	title, body := getTitleBody(input)
 	pr, err := findOrCreateGitlabMR(ctx, client, input.Repo.Owner, input.Repo.Name, &gitlab.CreateMergeRequestOptions{
 		Title:        &title,
 		Description:  &body,

--- a/push/pushGitlab.go
+++ b/push/pushGitlab.go
@@ -39,9 +39,14 @@ func GitlabPush(ctx context.Context, input Input, repoLimiter *time.Ticker, push
 		return Output{Success: false}, errors.New(string(output))
 	}
 
+	project, _, err := client.Projects.GetProject(fmt.Sprintf("%s/%s", input.Repo.Owner, input.Repo.Name), nil)
+	if err != nil {
+		return Output{Success: false}, err
+	}
+
 	// Open a pull request, if one doesn't exist already
 	head := input.BranchName
-	base := "master"
+	base := project.DefaultBranch
 
 	// Determine MR title and body
 	// Title is first line of commit message.


### PR DESCRIPTION
## JIRA

n/a

## Overview

**feat: use the default branch as the Gitlab PR target**

Previously, the target branch for the PR when using Gitlab was hardcoded
to "master". Now the repositories default branch will be used.

**refactor: the Gitlab PR body to be consistent with Github**

Now both Gitlab and Github have the same logic for creating the PR title
and body. It will use the first line of the commit as the title then
concatenate the commit body and the content of the PRBody file that is
passed in as a parameter

## Testing

Tested locally and have been using microplane with this patch for a while.
