### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _"the lemon is Git{Hub,Lab}"_
 Here are several ways to install microplane:
 
 - *Pre-built release* - You can download a pre-built version of Microplane from the [Github releases](https://github.com/Clever/microplane/releases).
-- *Compile it yourself*  - Run `go get github.com/Clever/microplane/cmd`. In this case the binary will be installed to `$GOPATH/bin/microplane`. Alternately, you can follow the steps under "Development", below.
+- *Compile it yourself*  - Run `go install github.com/Clever/microplane@latest`. In this case the binary will be installed to `$GOPATH/bin/microplane`. Alternately, you can follow the steps under "Development", below.
 - *Homebrew* - `brew install microplane`. The latest homebrew formula is [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/microplane.rb)
 
 ## Usage


### PR DESCRIPTION
## JIRA
_If there was a JIRA ticket associated with this changes, please link it here._

## Overview
_Give a high level description of your changes._
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

https://golang.org/doc/go-get-install-deprecation
## Testing
_Describe testing you did to ensure your changes work and that existing functionality was not broken by the changes._
I just had latest version of Go and tried mentioned command and it works.