### PR TITLE
improve push help docs for labels.

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -163,6 +163,6 @@ func init() {
 	pushCmd.Flags().StringVarP(&pushFlagThrottle, "throttle", "t", "30s", "Throttle number of pushes, e.g. '30s' means 1 push per 30 seconds")
 	pushCmd.Flags().StringVarP(&pushFlagAssignee, "assignee", "a", "", "Github user to assign the PR to")
 	pushCmd.Flags().StringVarP(&pushFlagBodyFile, "body-file", "b", "", "body of PR")
-	pushCmd.Flags().StringSliceVarP(&pushFlagLabels, "labels", "l", nil, "labels to attach to PR")
+	pushCmd.Flags().StringSliceVarP(&pushFlagLabels, "labels", "l", nil, "labels to attach to PR. for example: `-l 'first label' -l 'second label'`")
 	pushCmd.Flags().BoolVarP(&pushFlagDraft, "draft", "d", false, "push a draft pull request (only supported for github)")
 }


### PR DESCRIPTION
## JIRA
n/a 
closes #129

## Overview
The `labels` flag was difficult to use. This improves the docs.

## Testing
Build locally and sanity checked help text

```
$ ./bin/mp push --help
Push planned changes

Usage:
  mp push [flags]

Flags:
  -a, --assignee string                             Github user to assign the PR to
  -b, --body-file string                            body of PR
  -d, --draft                                       push a draft pull request (only supported for github)
  -h, --help                                        help for push
  -l, --labels -l 'first label' -l 'second label'   labels to attach to PR. for example: -l 'first label' -l 'second label'
  -t, --throttle string                             Throttle number of pushes, e.g. '30s' means 1 push per 30 seconds (default "30s")

Global Flags:
  -r, --repo string   single repo to operate on
```