### PR TITLE
Improve plan error output

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -79,7 +79,12 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 		// Set MICROPLANE_<X> convenience env vars, for use in user's script
 		execCmd.Env = append(os.Environ(), fmt.Sprintf("MICROPLANE_REPO=%s", input.RepoName))
 		if output, err := execCmd.CombinedOutput(); err != nil {
-			return Output{Success: false}, errors.New(string(output))
+			var exerr *exec.ExitError
+			if errors.As(err, &exerr) {
+				return Output{Success: false}, fmt.Errorf("[%s] %s", exerr, output)
+			} else {
+				return Output{Success: false}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Overview

Instead of just returning the command output, the `Plan` function will:
- return the go error if the planned command cannot be executed at all
- prefix the output with the error message containing the exit code if the command fails

## Testing
```
~/D/e/20220513-microplane-sandbox ❯❯❯ microplane plan -b test -m test -- foo
2022/05/13 12:44:12 planning 1 repos with parallelism limit [10]
2022/05/13 12:44:12 planning: gdetrez/sandbox
2022/05/13 12:44:12 1 errors:
 gdetrez/sandbox error: exec: "foo": executable file not found in $PATH

❯❯❯ microplane plan -b test -m test -- sh -c 'echo Kaboom!; exit 42'
2022/05/13 12:44:06 planning 1 repos with parallelism limit [10]
2022/05/13 12:44:06 planning: gdetrez/sandbox
2022/05/13 12:44:06 1 errors:
 gdetrez/sandbox error: [exit status 42] Kaboom!
```
