### PR TITLE
Remove --color param in "git diff" for the plane command

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -90,7 +90,7 @@ func Plan(ctx context.Context, input Input) (Output, error) {
 
 	// add the git diff to output, might be useful / convenient?
 	var gitDiff string
-	gitDiffCmd := exec.CommandContext(ctx, "git", "diff", "--color", "HEAD^", "HEAD")
+	gitDiffCmd := exec.CommandContext(ctx, "git", "diff", "HEAD^", "HEAD")
 	gitDiffCmd.Dir = planDir
 	output, err := gitDiffCmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This param adds extra chars in the git diff, and because of this, the parser doesn't know how to parser it.

## JIRA
NA

## Overview
This param adds extra chars in the git diff, and because of this, the parser doesn't know how to parser it.

## Testing
Before the change: Init, Clone, Plan, Status, status shows 0 file changes.
After the change: Init, Clone, Plan, Status, status shows 174 file changes.