### PR TITLE
Reduce parallelism to 3 threads

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -30,7 +30,7 @@ func writeJSON(obj interface{}, path string) error {
 }
 
 func parallelize(repos []lib.Repo, f func(lib.Repo, context.Context) error) error {
-	return parallelizeLimited(repos, f, 10)
+	return parallelizeLimited(repos, f, 3)
 }
 
 // parallelize take a list of repos and applies a function (clone, plan, ...) to them

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -30,7 +30,7 @@ func writeJSON(obj interface{}, path string) error {
 }
 
 func parallelize(repos []lib.Repo, f func(lib.Repo, context.Context) error) error {
-	return parallelizeLimited(repos, f, 3)
+	return parallelizeLimited(repos, f, 1)
 }
 
 // parallelize take a list of repos and applies a function (clone, plan, ...) to them


### PR DESCRIPTION
GitHub has lately been restricting concurrent API requests, which severely limits and causes timeouts / failed cloning and other operations.

This reduces parallelism to 3 so that there is less chance of inducing timeouts.